### PR TITLE
feat: raise events when configuration changes and tests

### DIFF
--- a/src/compression-manager.js
+++ b/src/compression-manager.js
@@ -18,13 +18,22 @@
 
 import fs from 'fs';
 const fsPromises = fs.promises;
+import path from "path";
 import util from 'util';
 import child_process from 'child_process';
+import {ensureDirExists} from "./utils.js";
 const exec = util.promisify(child_process.exec);
 
-async function compressFile(fileName) {
-    await fsPromises.stat(fileName); // will throw if file does not exist preventing empty compressed archives
-    await exec(`tar -zcvf ${fileName}.tar.gz ${fileName}`);
+async function compressFile(filePath) {
+    if(!path.isAbsolute(filePath)){
+        filePath = path.resolve(filePath);
+    }
+    const dirName = path.dirname(filePath);
+    const fileName = path.basename(filePath);
+    await ensureDirExists(dirName);
+    await fsPromises.stat(filePath); // will throw if file does not exist preventing empty compressed archives
+    await exec(`tar -zcvf ${dirName}/${fileName}.tar.gz ${filePath}`);
+    return `${dirName}/${fileName}.tar.gz`;
 }
 
 export {

--- a/src/file-manager.js
+++ b/src/file-manager.js
@@ -17,7 +17,6 @@
  */
 
 import fs from 'fs';
-const fsPromises = fs.promises;
 import {getNewV1FileName, getUnixTimestampUTCNow, getUTF8StringSizeInBytes, ensureDirExists} from "./utils.js";
 import path from "path";
 
@@ -81,7 +80,12 @@ async function pushDataForApp(appName, jsonStringData) {
     handle.bytesWritten = handle.bytesWritten + getUTF8StringSizeInBytes(jsonStringData);
 }
 
+function getAllAppNames() {
+    return Object.keys(appAnalyticsFileHandle);
+}
+
 export {
     pushDataForApp,
-    getDumpFileToUpload
+    getDumpFileToUpload,
+    getAllAppNames
 };

--- a/test/unit/compression-manager-test.spec.js
+++ b/test/unit/compression-manager-test.spec.js
@@ -20,6 +20,7 @@
 /*global describe, it*/
 
 import * as chai from 'chai';
+import path from "path";
 import {getNewV1FileName} from "../../src/utils.js";
 import {compressFile} from "../../src/compression-manager.js";
 import {fileCanBeRead, deleteFile} from "./test-utils.js";
@@ -40,13 +41,29 @@ describe('compression-manager.js Tests', function() {
         expect(await fileCanBeRead(compressedFileName)).to.be.false;
     });
 
-    it('Should compress valid file', async function() {
+    it('Should compress valid file with relative path', async function() {
         let fileName = 'package.json';
-        let compressedFileName = `${fileName}.tar.gz`;
+        let expectedCompressedFileName = path.resolve(`${fileName}.tar.gz`);
+        let compressedFileName = "";
         let err = null;
-        await deleteFile(compressedFileName);
+        await deleteFile(expectedCompressedFileName);
         try{
-            await compressFile(fileName);
+            compressedFileName = await compressFile(fileName);
+        } catch (error) {
+            err = error;
+        }
+        expect(err).to.be.null;
+        expect(compressedFileName).to.equal(expectedCompressedFileName);
+        expect(await fileCanBeRead(compressedFileName)).to.be.true;
+        expect(await deleteFile(compressedFileName)).to.be.true;
+    });
+
+    it('Should compress valid file with absolute path', async function() {
+        let absoluteFilePath = path.resolve('package.json');
+        let compressedFileName = "";
+        let err = null;
+        try{
+            compressedFileName = await compressFile(absoluteFilePath);
         } catch (error) {
             err = error;
         }

--- a/test/unit/file-manager-test.spec.js
+++ b/test/unit/file-manager-test.spec.js
@@ -20,13 +20,13 @@
 /*global describe, it*/
 
 import * as chai from 'chai';
-import {pushDataForApp, getDumpFileToUpload} from "../../src/file-manager.js";
+import {pushDataForApp, getDumpFileToUpload, getAllAppNames} from "../../src/file-manager.js";
 import {readJsonFile, getUnixTimestampUTCNow} from "../../src/utils.js";
 import {deleteFile} from "./test-utils.js";
 
 let expect = chai.expect;
 
-describe('config-manager.js Tests', function() {
+describe('file-manager.js Tests', function() {
     it('Should get dump file to Upload if exists', async function() {
         const appName = "testApp";
         await pushDataForApp(appName, JSON.stringify({"message": "hello"}));
@@ -39,6 +39,20 @@ describe('config-manager.js Tests', function() {
         expect(writtenDumpFile["unixTimestampUTCAtServer"]).to.be.lessThan(getUnixTimestampUTCNow());
         expect(writtenDumpFile["clientAnalytics"][2]['endTime']).to.be.lessThan(getUnixTimestampUTCNow());
         await deleteFile(fileToUpload.filePath);
+    });
+
+    it('Should return all app names that has a valid dump file', async function() {
+        await pushDataForApp("testApp1", JSON.stringify({"message": "hello"}));
+        await pushDataForApp("testApp2", JSON.stringify({"message": "world"}));
+
+        let appNames = getAllAppNames();
+        expect(appNames.length).to.equal(2);
+        expect(appNames).to.contain("testApp1");
+        expect(appNames).to.contain("testApp2");
+
+        // clean up
+        await deleteFile((await getDumpFileToUpload("testApp1")).filePath);
+        await deleteFile((await getDumpFileToUpload("testApp2")).filePath);
     });
 
     it('Should get empty if there is no dump file to upload', async function() {


### PR DESCRIPTION
* Raise events when configuration changes so that the server can change config without needing a restart.
* compression-manager now works with both absolute and relative paths