### PR TITLE
fix: data folder creation issues when load testing

### DIFF
--- a/src/compression-manager.js
+++ b/src/compression-manager.js
@@ -21,7 +21,7 @@ const fsPromises = fs.promises;
 import path from "path";
 import util from 'util';
 import child_process from 'child_process';
-import {ensureDirExists} from "./utils.js";
+import {ensureDirExistsSync} from "./utils.js";
 const exec = util.promisify(child_process.exec);
 
 async function compressFile(filePath) {
@@ -30,7 +30,7 @@ async function compressFile(filePath) {
     }
     const dirName = path.dirname(filePath);
     const fileName = path.basename(filePath);
-    await ensureDirExists(dirName);
+    ensureDirExistsSync(dirName);
     await fsPromises.stat(filePath); // will throw if file does not exist preventing empty compressed archives
     await exec(`tar -zcvf ${dirName}/${fileName}.tar.gz -C ${dirName} ${fileName}`);
     return `${dirName}/${fileName}.tar.gz`;

--- a/src/file-manager.js
+++ b/src/file-manager.js
@@ -17,7 +17,7 @@
  */
 
 import fs from 'fs';
-import {getNewV1FileName, getUnixTimestampUTCNow, getUTF8StringSizeInBytes, ensureDirExists} from "./utils.js";
+import {getNewV1FileName, getUnixTimestampUTCNow, getUTF8StringSizeInBytes, ensureDirExistsSync} from "./utils.js";
 import path from "path";
 
 // // file Schema sample , see https://github.com/aicore/Core-Analytics-Server/wiki#analytics-backend
@@ -52,7 +52,7 @@ async function _createNewHandleForApp(appName) {
    "schemaVersion" : 1,
    "unixTimestampUTCAtServer" : ${startTime},
    "clientAnalytics":[\n`;
-    await ensureDirExists(dataPath);
+    await ensureDirExistsSync(dataPath);
     const writableStream = fs.createWriteStream(filePath, {flags:'a'});
     writableStream.write(fileContent, UTF8);
     const handle = {
@@ -86,6 +86,7 @@ async function pushDataForApp(appName, jsonStringData) {
     let handle = appAnalyticsFileHandle[appName];
     if(!handle){
         handle = await _createNewHandleForApp(appName);
+        appAnalyticsFileHandle[appName] = handle;
     }
     handle.writableStream.write(`\t${jsonStringData},\n`, UTF8);
     handle.bytesWritten = handle.bytesWritten + getUTF8StringSizeInBytes(jsonStringData);

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@
 
 import express from 'express';
 import {processDataFromClient} from "./analytics-data-manager.js";
+import {setupFileRotationTimers} from "./file-rotation-manager.js";
 
 const app = express();
 const port = 3000;
@@ -33,5 +34,7 @@ app.post('/ingest', async function (req, res, next) {
 app.listen(port, () => {
     console.log(`Analytics server listening at http://localhost:${port}`);
 });
+
+setupFileRotationTimers();
 
 export default app;

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,8 +43,8 @@ async function readJsonFile(fileName) {
     return JSON.parse(await fsPromises.readFile(fileName, 'utf8'));
 }
 
-async function ensureDirExists(path) {
-    await fsPromises.mkdir(path, { recursive: true });
+function ensureDirExistsSync(path) {
+    fs.mkdirSync(path, { recursive: true });
 }
 
 function getUTF8StringSizeInBytes(str) {
@@ -63,7 +63,7 @@ async function deleteFile(fileName) {
 export {
     getNewV1FileName,
     getUnixTimestampUTCNow,
-    ensureDirExists,
+    ensureDirExistsSync,
     readJsonFile,
     readTextFile,
     writeAsJson,


### PR DESCRIPTION
When a large number of post requests were raised, a large number of dump files were getting created as the async root dir creation created inconsistencies. As the root dir creation is a rare event, changed to sync.