### PR TITLE
feat: add accountID field to analytics data

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ config changes to the user.
 section for more details.
 6. `allowedAppNames`: An array that whitelists the appNames that this analytics
 server will accept. if `*` is specified in the list, then everything will be accepted.
+7. `allowedAccountIDs` An array of account IDs allowed to use this server. Defaults to `*`
 
 ### rotateDumpFiles configuration
 1. `maxFileSizeBytes`: When the current dump file size crosses this threshold, it will be rotated 

--- a/analytics-config.json
+++ b/analytics-config.json
@@ -5,6 +5,9 @@
   "allowedAppNames": [
     "*"
   ],
+  "allowedAccountIDs":[
+    "*"
+  ],
   "rotateDumpFiles": {
     "maxFileSizeBytes": 100000000,
     "rotateInEveryNSeconds": 600,

--- a/src/analytics-data-manager.js
+++ b/src/analytics-data-manager.js
@@ -78,6 +78,14 @@ function isAllowedAppName(appName) {
     return false;
 }
 
+function isAllowedAccountID(accountID) {
+    const allowedAppNames = getConfig("allowedAccountIDs");
+    if(accountID && allowedAppNames.includes("*") || allowedAppNames.includes(accountID)){
+        return true;
+    }
+    return false;
+}
+
 function validateInput(clientData) {
     let errors = [];
     if(clientData["schemaVersion"] !== 1){
@@ -85,6 +93,9 @@ function validateInput(clientData) {
     }
     if(!isAllowedAppName(clientData["appName"])){
         errors.push("Invalid_appName");
+    }
+    if(!isAllowedAccountID(clientData["accountID"])){
+        errors.push("Invalid_accountID");
     }
     if(!clientData["uuid"]){
         errors.push("Invalid_uuid");

--- a/src/analytics-data-manager.js
+++ b/src/analytics-data-manager.js
@@ -79,8 +79,8 @@ function isAllowedAppName(appName) {
 }
 
 function isAllowedAccountID(accountID) {
-    const allowedAppNames = getConfig("allowedAccountIDs");
-    if(accountID && allowedAppNames.includes("*") || allowedAppNames.includes(accountID)){
+    const allowedAccountIDs = getConfig("allowedAccountIDs");
+    if(accountID && allowedAccountIDs.includes("*") || allowedAccountIDs.includes(accountID)){
         return true;
     }
     return false;

--- a/test/unit/analytics-data-manager-test.spec.js
+++ b/test/unit/analytics-data-manager-test.spec.js
@@ -50,6 +50,7 @@ describe('analytics-data-manager.js Tests', function() {
     it('should fail validation if schema version is not 1', async function() {
         const response = await processDataFromClient({
             "schemaVersion": 2,
+            "accountID": "acc1",
             "appName": "testApp",
             "uuid": "default",
             "sessionID": "def",
@@ -72,6 +73,7 @@ describe('analytics-data-manager.js Tests', function() {
         });
 
         expect(response.statusCode).to.equal(400);
+        expect(response.returnData.errors.includes("Invalid_accountID")).to.be.true;
         expect(response.returnData.errors.includes("Invalid_appName")).to.be.true;
         expect(response.returnData.errors.includes("Invalid_uuid")).to.be.true;
         expect(response.returnData.errors.includes("Invalid_sessionID")).to.be.true;
@@ -79,7 +81,7 @@ describe('analytics-data-manager.js Tests', function() {
         expect(response.returnData.errors.includes("Invalid_unixTimestampUTC")).to.be.true;
         expect(response.returnData.errors.includes("Invalid_numEventsTotal")).to.be.true;
         expect(response.returnData.errors.includes("Invalid_events")).to.be.true;
-        expect(response.returnData.errors.length).to.equal(7);
+        expect(response.returnData.errors.length).to.equal(8);
     });
 
     it('should push to dump file if validation success', async function() {
@@ -89,6 +91,7 @@ describe('analytics-data-manager.js Tests', function() {
         });
         const response = await processDataFromClient({
             "schemaVersion": 1,
+            "accountID": "acc1",
             "appName": "testApp",
             "uuid": "uuid",
             "sessionID": "session1",
@@ -109,6 +112,7 @@ describe('analytics-data-manager.js Tests', function() {
         setupStatusManagerTimers();
         const sampleData = {
             "schemaVersion": 1,
+            "accountID": "acc1",
             "appName": "testApp",
             "uuid": "uuid",
             "sessionID": "session1",
@@ -139,6 +143,7 @@ describe('analytics-data-manager.js Tests', function() {
         setupStatusManagerTimers();
         const sampleData = {
             "schemaVersion": 1,
+            "accountID": "acc1",
             "appName": "testApp",
             "uuid": "uuid",
             "sessionID": "session1",


### PR DESCRIPTION
* Add `allowedAccountIDs` to config. An array that whitelists the accountIDs that this analytics server will accept. if `*` is specified in the list, then everything will be accepted.
* Add required field `accountID` to analytics data.