### PR TITLE
chore: remove granularitySec from ingest and validations

### DIFF
--- a/src/analytics-data-manager.js
+++ b/src/analytics-data-manager.js
@@ -23,7 +23,6 @@
 //     "appName" : "app1",
 //     "uuid": "u1",
 //     "sessionID": "s1",
-//     "granularitySec" : 3,
 //     "unixTimestampUTC" : 1643043376,
 //     "events":{
 //     "eventType":{
@@ -72,18 +71,12 @@ function _getFailureResponse(statusCode, errorsArray) {
 
 function isAllowedAppName(appName) {
     const allowedAppNames = getConfig("allowedAppNames");
-    if(appName && allowedAppNames.includes("*") || allowedAppNames.includes(appName)){
-        return true;
-    }
-    return false;
+    return (appName && (allowedAppNames.includes("*") || allowedAppNames.includes(appName)));
 }
 
 function isAllowedAccountID(accountID) {
     const allowedAccountIDs = getConfig("allowedAccountIDs");
-    if(accountID && allowedAccountIDs.includes("*") || allowedAccountIDs.includes(accountID)){
-        return true;
-    }
-    return false;
+    return (accountID && (allowedAccountIDs.includes("*") || allowedAccountIDs.includes(accountID)));
 }
 
 function validateInput(clientData) {
@@ -102,9 +95,6 @@ function validateInput(clientData) {
     }
     if(!clientData["sessionID"]){
         errors.push("Invalid_sessionID");
-    }
-    if(!clientData["granularitySec"]){
-        errors.push("Invalid_granularitySec");
     }
     if(!clientData["unixTimestampUTC"]){
         errors.push("Invalid_unixTimestampUTC");
@@ -127,9 +117,8 @@ function getServerStats(timeFrame) {
         return getAllHoursMetric();
     } else if(timeFrame==="dd") {
         return getAllDaysMetric();
-    } else {
-        return getAllSecondsMetric();
     }
+    return getAllSecondsMetric();
 }
 
 function _updateServerStats(clientData) {

--- a/test/unit/analytics-data-manager-test.spec.js
+++ b/test/unit/analytics-data-manager-test.spec.js
@@ -54,7 +54,6 @@ describe('analytics-data-manager.js Tests', function() {
             "appName": "testApp",
             "uuid": "default",
             "sessionID": "def",
-            "granularitySec": 3,
             "unixTimestampUTC": 1643043376,
             "numEventsTotal": 5,
             "events": {}
@@ -77,11 +76,10 @@ describe('analytics-data-manager.js Tests', function() {
         expect(response.returnData.errors.includes("Invalid_appName")).to.be.true;
         expect(response.returnData.errors.includes("Invalid_uuid")).to.be.true;
         expect(response.returnData.errors.includes("Invalid_sessionID")).to.be.true;
-        expect(response.returnData.errors.includes("Invalid_granularitySec")).to.be.true;
         expect(response.returnData.errors.includes("Invalid_unixTimestampUTC")).to.be.true;
         expect(response.returnData.errors.includes("Invalid_numEventsTotal")).to.be.true;
         expect(response.returnData.errors.includes("Invalid_events")).to.be.true;
-        expect(response.returnData.errors.length).to.equal(8);
+        expect(response.returnData.errors.length).to.equal(7);
     });
 
     it('should push to dump file if validation success', async function() {
@@ -95,7 +93,6 @@ describe('analytics-data-manager.js Tests', function() {
             "appName": "testApp",
             "uuid": "uuid",
             "sessionID": "session1",
-            "granularitySec": 3,
             "unixTimestampUTC": 1643043376,
             "numEventsTotal": 5,
             "events": {}
@@ -116,7 +113,6 @@ describe('analytics-data-manager.js Tests', function() {
             "appName": "testApp",
             "uuid": "uuid",
             "sessionID": "session1",
-            "granularitySec": 3,
             "unixTimestampUTC": 1643043376
         };
         await processDataFromClient(sampleData);
@@ -147,7 +143,6 @@ describe('analytics-data-manager.js Tests', function() {
             "appName": "testApp",
             "uuid": "uuid",
             "sessionID": "session1",
-            "granularitySec": 3,
             "unixTimestampUTC": 1643043376,
             "numEventsTotal": 5,
             "events": {


### PR DESCRIPTION
granularitySec is not needed to be persisted with each analytics client entry as the analytics client sends over drift time for each event.
Client will no longer send granularitySec, so removing from server.